### PR TITLE
Helper function implementation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 *.pyc
 *.log
 .snakemake

--- a/cytosnake/cli/args.py
+++ b/cytosnake/cli/args.py
@@ -174,7 +174,14 @@ class CliControlPanel:
             help="path to metadata directory",
             required=True,
         )
-        parser.add_argument("-b", "--barcode", type=str, help="path to barcodes file")
+        parser.add_argument(
+            "-b",
+            "--barcode",
+            type=str,
+            required=False,
+            default=None,
+            help="path to barcodes file",
+        )
         parser.add_argument(
             "--datatype",
             choices=list(self.data_type),

--- a/cytosnake/cli/cmd.py
+++ b/cytosnake/cli/cmd.py
@@ -6,7 +6,7 @@ cmd.py Module
 Generates CLI interface in order to interact with CytoSnake.
 """
 import sys
-from logging import Logger
+import logging
 
 # cytosnake imports
 from cytosnake.cli.args import CliControlPanel
@@ -29,6 +29,10 @@ def run_cmd() -> None:
     -------
     None
     """
+
+    # set logging configurations
+    logging.basicConfig(level="DEBUG")
+
     # create args handler
     # -- Cli Control Panel
     args_handler = CliControlPanel(sys.argv)
@@ -55,7 +59,7 @@ def run_cmd() -> None:
                 )
 
             # setting up input files for cytosnake
-            Logger.info("Formatting input files")
+            logging.info(msg="Formatting input files")
             init_args = args_handler.parse_init_args()
 
             # identifying which data type was added and how to set it up
@@ -77,7 +81,7 @@ def run_cmd() -> None:
             # now that the data is created, set up the current directory
             # into a project directory
             setup_cytosnake_env()
-            Logger.info("Initialization complete")
+            logging.info("Initialization complete")
 
         # Executed if the user is using the `run` mode. This will execute the
         # workflow that are found within the `workflows` folder

--- a/cytosnake/cli/cmd.py
+++ b/cytosnake/cli/cmd.py
@@ -80,7 +80,7 @@ def run_cmd() -> None:
 
             # now that the data is created, set up the current directory
             # into a project directory
-            setup_cytosnake_env()
+            setup_cytosnake_env(args=init_args)
             logging.info("Initialization complete")
 
         # Executed if the user is using the `run` mode. This will execute the

--- a/cytosnake/cli/cmd.py
+++ b/cytosnake/cli/cmd.py
@@ -7,6 +7,7 @@ Generates CLI interface in order to interact with CytoSnake.
 """
 import sys
 import logging
+from pathlib import Path
 
 # cytosnake imports
 from cytosnake.cli.args import CliControlPanel
@@ -93,8 +94,9 @@ def run_cmd() -> None:
                 sys.exit(0)
 
             # parsing workflow parameters
-            print(f"INFO: Executing {args_handler.workflow} workflow")
             wf_params = args_handler.parse_workflow_args()
+            wf_name = Path(wf_params.workflow).name
+            print(f"Executing {wf_name} workflow")
             wf_executor = workflow_executor(
                 workflow=wf_params.workflow,
                 n_cores=wf_params.max_cores,

--- a/cytosnake/cli/setup_init.py
+++ b/cytosnake/cli/setup_init.py
@@ -30,7 +30,12 @@ def init_cp_data(data_fp: Union[list[str], str], metadata_fp: str, barcode_fp: s
         )
 
     # setting up paths
-    barcode_path_obj = Path(barcode_fp)
+    # -- barcode
+    barcode_path_obj = barcode_fp
+    if barcode_fp is not None:
+        barcode_path_obj = Path(barcode_fp)
+
+    # -- metadata_path
     metadata_path_obj = Path(metadata_fp)
 
     # create data folder on working directory
@@ -46,9 +51,10 @@ def init_cp_data(data_fp: Union[list[str], str], metadata_fp: str, barcode_fp: s
         sym_link.symlink_to(target_file)
 
     # generating symlinks of provided barcode file and metadata directory is
-    barcode_target = Path(f"../{barcode_path_obj}")
-    barcode_symlink = Path(f"./{str(data_dir_obj)}/{barcode_path_obj.name}")
-    barcode_symlink.symlink_to(barcode_target)
+    if barcode_fp is not None:
+        barcode_target = Path(f"../{barcode_path_obj}")
+        barcode_symlink = Path(f"./{str(data_dir_obj)}/{barcode_path_obj.name}")
+        barcode_symlink.symlink_to(barcode_target)
 
     metadata_target = Path(f"../{metadata_path_obj}")
     metadata_symlink = Path(f"./{str(data_dir_obj)}/{metadata_path_obj.name}")

--- a/cytosnake/helpers/helper_funcs.py
+++ b/cytosnake/helpers/helper_funcs.py
@@ -85,7 +85,7 @@ def get_metadata_dir() -> str:
     """
 
     try:
-        metadata_dir = PATHS["project_dir"]["data_dir_conts"]["metadata"]
+        metadata_dir = PATHS["project_dir"]["data_directory_contents"]["metadata"]
     except KeyError:
         raise KeyError("Unable to find Metadata folder")
 

--- a/cytosnake/helpers/helper_funcs.py
+++ b/cytosnake/helpers/helper_funcs.py
@@ -10,7 +10,14 @@ from pathlib import Path
 
 from cytosnake.utils.config_utils import load_meta_path_configs
 
+# loading in config as global variables
+PATHS = load_meta_path_configs()
+RESULTS_DIR = "../results"
 
+
+# ------------------------------
+# Inputs helper functions
+# ------------------------------
 def get_data_folder() -> Path:
     """Returns absolute path that points to the data folder.
 
@@ -72,3 +79,22 @@ def get_metadata_dir() -> str:
     """
     data_dir_path = get_data_folder()
     return str(data_dir_path / "{metadata}")
+
+
+# ------------------------------
+# Output helper functions
+# ------------------------------
+def cell_count_output() -> str:
+    """Generates output path for cell counts;
+
+    Returns
+    -------
+    Path
+        path were the cell count data will be produced.
+    """
+    results_path = Path(PATHS["projet_dir_path"]) / "results"
+    output_name = "cell_counts"
+    ext = ".csv"
+
+    # building the string
+    return str(results_path / f"{output_name}.{ext}")

--- a/cytosnake/helpers/helper_funcs.py
+++ b/cytosnake/helpers/helper_funcs.py
@@ -117,18 +117,12 @@ def cell_count_output() -> str:
 
 
 def aggregate_output() -> str:
-    """Generates output path for cell counts;
-
-    Parameters
-    ----------
-    wildcards list[str]
-        names that point to a unique file
+    """Generates output path for cell counts.
 
     Returns
     -------
     list[str], str
-        path to aggregate output file. If multiple outputs, a list of paths are
-        returned
+        path to aggregate output file.
     """
 
     # components of output string
@@ -137,8 +131,78 @@ def aggregate_output() -> str:
     ext = "csv.gz"
 
     # constructing file output string
-    output_string = str(results_path / f"{output_name}.{ext}")
-    return output_string
+    return str(results_path / f"{output_name}.{ext}")
+
+
+def annotated_output() -> str:
+    """Generates output path for annotated dataset
+
+    Returns
+    -------
+    str
+        path to annotated output file
+    """
+    # components of output string for annotated profile
+    results_path = Path(PATHS["project_dir_path"]) / "results"
+    output_name = "{file_name}_annotated"
+    ext = "csv.gz"
+
+    # constructing file output string
+    return str(results_path / f"{output_name}.{ext}")
+
+
+def normalized_output() -> str:
+
+    """Generates output path for normalized dataset
+
+    Returns
+    -------
+    str
+        path to normalized output file
+    """
+    # components of output string for annotated profile
+    results_path = Path(PATHS["project_dir_path"]) / "results"
+    output_name = "{file_name}_normalized"
+    ext = "csv.gz"
+
+    # constructing file output string
+    return str(results_path / f"{output_name}.{ext}")
+
+
+def selected_features_output() -> str:
+
+    """Generates output path for selected features dataset
+
+    Returns
+    -------
+    str
+        path to selected features output file
+    """
+    # components of output string for annotated profile
+    results_path = Path(PATHS["project_dir_path"]) / "results"
+    output_name = "{file_name}_features"
+    ext = "csv.gz"
+
+    # constructing file output string
+    return str(results_path / f"{output_name}.{ext}")
+
+
+def consensus_output() -> str:
+
+    """Generates output path for consensus  dataset
+
+    Returns
+    -------
+    str
+        path to selected features output file
+    """
+    # components of output string for annotated profile
+    results_path = Path(PATHS["project_dir_path"]) / "results"
+    output_name = "consensus_profile"
+    ext = "csv.gz"
+
+    # constructing file output string
+    return str(results_path / f"{output_name}.{ext}")
 
 
 # ------------------------------

--- a/cytosnake/helpers/helper_funcs.py
+++ b/cytosnake/helpers/helper_funcs.py
@@ -14,7 +14,6 @@ from cytosnake.guards.path_guards import is_valid_path
 
 # loading in config as global variables
 PATHS = load_meta_path_configs()
-RESULTS_DIR = "../results"
 
 
 # ------------------------------

--- a/cytosnake/utils/cyto_paths.py
+++ b/cytosnake/utils/cyto_paths.py
@@ -29,10 +29,6 @@ def get_meta_path() -> Path:
     if proj_dir is None:
         raise FileNotFoundError("Current directory is not a project folder")
 
-    # # checking if it is a valid path
-    # if not is_cytosnake_dir():
-    #     raise FileNotFoundError("Unable to find project ")
-
     return proj_dir.absolute()
 
 
@@ -187,6 +183,9 @@ def get_project_dirpaths(args: Namespace) -> dict:
     for _file in proj_root_path.glob("*"):
         if _file.name in ignore_dirs:
             continue
+
+        # if the file is a directory, get paths of individual files
+        # -- this is done recursively.
         if _file.is_dir():
             abs_path = str(_file.absolute())
             all_dirs[_file.name] = abs_path

--- a/cytosnake/utils/cyto_paths.py
+++ b/cytosnake/utils/cyto_paths.py
@@ -24,7 +24,7 @@ def get_meta_path() -> Path:
 
     # getting project directory
     proj_dir = find_project_dir()
-    if not proj_dir.exists():
+    if proj_dir is None:
         raise FileNotFoundError("Current directory is not a project folder")
 
     return proj_dir.absolute()

--- a/cytosnake/utils/cyto_paths.py
+++ b/cytosnake/utils/cyto_paths.py
@@ -205,6 +205,6 @@ def get_project_dirpaths(args: Namespace) -> dict:
                 data_dir_conts["data"] = abs_path
                 data_dir_conts["barcode"] = str(abs_data_path / args.barcode)
                 data_dir_conts["metadata"] = str(abs_data_path / args.metadata)
-                all_dirs["data_dir_conts"] = data_dir_conts
+                all_dirs["data_directory_contents"] = data_dir_conts
 
     return all_dirs

--- a/cytosnake/utils/cyto_paths.py
+++ b/cytosnake/utils/cyto_paths.py
@@ -3,7 +3,6 @@ module: cyto_paths.py
 
 This module will contain functions that handles `cytosnake's` pathing
 """
-
 from pathlib import Path
 from typing import Optional, TypeVar
 
@@ -194,15 +193,19 @@ def get_project_dirpaths(args: Namespace) -> dict:
 
             # use the name space arguments to write _paths.yaml
             if _file.name.lower() == "data":
+                abs_data_path = Path(abs_path)
 
                 # creating  dictionary for the plate data
                 data_dir_conts = {}
                 for platename in args.data:
                     name = platename.split(".")[0]
-                    platedata_path = Path(abs_path) / platename
+                    platedata_path = abs_data_path / platename
                     data_dir_conts[name] = str(platedata_path)
 
+                # adding single files paths
                 data_dir_conts["data"] = abs_path
+                data_dir_conts["barcode"] = str(abs_data_path / args.barcode)
+                data_dir_conts["metadata"] = str(abs_data_path / args.metadata)
                 all_dirs["data_dir_conts"] = data_dir_conts
 
     return all_dirs

--- a/cytosnake/utils/cyto_paths.py
+++ b/cytosnake/utils/cyto_paths.py
@@ -190,7 +190,7 @@ def get_project_dirpaths(args: Namespace) -> dict:
             abs_path = str(_file.absolute())
             all_dirs[_file.name] = abs_path
 
-            # use the name space arguments to write _paths.yaml
+            # use the namespace arguments to write _paths.yaml
             if _file.name.lower() == "data":
                 abs_data_path = Path(abs_path)
 

--- a/cytosnake/utils/cyto_paths.py
+++ b/cytosnake/utils/cyto_paths.py
@@ -203,7 +203,10 @@ def get_project_dirpaths(args: Namespace) -> dict:
 
                 # adding single files paths
                 data_dir_conts["data"] = abs_path
-                data_dir_conts["barcode"] = str(abs_data_path / args.barcode)
+                if args.barcode is None:
+                    data_dir_conts["barcode"] = None
+                else:
+                    data_dir_conts["barcode"] = str(abs_data_path / args.barcode)
                 data_dir_conts["metadata"] = str(abs_data_path / args.metadata)
                 all_dirs["data_directory_contents"] = data_dir_conts
 

--- a/cytosnake/utils/cytosnake_setup.py
+++ b/cytosnake/utils/cytosnake_setup.py
@@ -9,6 +9,7 @@ meta data for cytosnake to use.
 import json
 import shutil
 from pathlib import Path
+from typing import TypeVar
 
 from cytosnake.common.errors import display_error
 from cytosnake.utils.cyto_paths import (
@@ -17,6 +18,10 @@ from cytosnake.utils.cyto_paths import (
     get_project_dirpaths,
     get_workflow_fpaths,
 )
+
+# creating type hints without importing the modules
+# -- user defined generic types
+Namespace = TypeVar("Namespace")
 
 
 def create_cytosnake_dir() -> None:
@@ -68,13 +73,14 @@ def transport_project_files() -> None:
         src_path = pkg_path / target_dir
         target_dst = proj_path / target_dir
         if not src_path.exists():
+            print("DEBUGG:", str(src_path))
             raise FileNotFoundError(f"{src_path} does not exist")
 
         # move to dest: working project directory
         shutil.copytree(src_path, target_dst)
 
 
-def generate_meta_path_configs() -> None:
+def generate_meta_path_configs(args: Namespace) -> None:
     """constructs a `_paths.yaml` file that contains the necessary path
     information for file handling. this allows `cytosnake` to know which folders
     to look for when performing tasks.
@@ -88,7 +94,7 @@ def generate_meta_path_configs() -> None:
     # get all pathing info
     cwd_path = Path().absolute()
     cwd_str = str(cwd_path)
-    dir_paths = {"project_dir": get_project_dirpaths()}
+    dir_paths = {"project_dir": get_project_dirpaths(args=args)}
     config_fpaths = {"config_dir": get_config_fpaths()}
     workflow_fpath = {"workflow_dir": get_workflow_fpaths()}
     proj_dir_path = {"project_dir_path": cwd_str}
@@ -103,7 +109,7 @@ def generate_meta_path_configs() -> None:
         json.dump(all_paths_dict, stream, indent=4)
 
 
-def setup_cytosnake_env() -> None:
+def setup_cytosnake_env(args: Namespace) -> None:
     """main wrapper function that sets up current directory into a `cytosnake`
     project directory. this means that all the analysis being conducted within
     the current directory will allow
@@ -116,4 +122,4 @@ def setup_cytosnake_env() -> None:
     transport_project_files()
 
     # create `_paths.yaml` path meta data in `.cytosnake` project dir
-    generate_meta_path_configs()
+    generate_meta_path_configs(args=args)

--- a/cytosnake/utils/cytosnake_setup.py
+++ b/cytosnake/utils/cytosnake_setup.py
@@ -73,7 +73,6 @@ def transport_project_files() -> None:
         src_path = pkg_path / target_dir
         target_dst = proj_path / target_dir
         if not src_path.exists():
-            print("DEBUGG:", str(src_path))
             raise FileNotFoundError(f"{src_path} does not exist")
 
         # move to dest: working project directory

--- a/workflows/envs/cytominer_env.yaml
+++ b/workflows/envs/cytominer_env.yaml
@@ -4,8 +4,8 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python>=3.7.0
+  - python>=3.10.0
   - pyyaml
   - pip
   - pip:
-      - git+https://github.com/cytomining/pycytominer.git@afac3ea16818ad25f37318ecd5c5090c0eff5806
+      - git+https://github.com/cytomining/pycytominer.git@b2c6cc4580cf9e1c040a7370b99976916a22e756

--- a/workflows/envs/cytominer_env.yaml
+++ b/workflows/envs/cytominer_env.yaml
@@ -4,9 +4,8 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python>=3.10.0
+  - python=3.9
   - pyyaml
   - pip
   - pip:
       - git+https://github.com/cytomining/pycytominer.git@b2c6cc4580cf9e1c040a7370b99976916a22e756
-      

--- a/workflows/envs/cytominer_env.yaml
+++ b/workflows/envs/cytominer_env.yaml
@@ -9,3 +9,4 @@ dependencies:
   - pip
   - pip:
       - git+https://github.com/cytomining/pycytominer.git@b2c6cc4580cf9e1c040a7370b99976916a22e756
+      

--- a/workflows/rules/common.smk
+++ b/workflows/rules/common.smk
@@ -25,7 +25,7 @@ METADATA_DIR = hf.get_metadata_dir()
 # -------
 # OUTPUTS
 # -------
-# -- extended = list of the file names with given wildcard
+# -- extended = list of the file names with a given wildcard
 AGGREGATE_DATA = hf.aggregate_output()
 CELL_COUNTS = hf.cell_count_output()
 

--- a/workflows/rules/common.smk
+++ b/workflows/rules/common.smk
@@ -1,7 +1,7 @@
 """
 rule module: common.smk
 
-common.smk is a workflow module that setups the expected input and output paths
+common.smk is a workflow module that sets up the expected input and output paths
 for the main analytical workflow.
 """
 from snakemake.io import expand

--- a/workflows/rules/common.smk
+++ b/workflows/rules/common.smk
@@ -1,0 +1,44 @@
+"""
+rule module: common.smk
+
+common.smk is a workflow module that setups the expected input and output paths
+for the main analytical workflow.
+"""
+from snakemake.io import expand
+from cytosnake.helpers import helper_funcs as hf
+from cytosnake.utils.config_utils import load_data_path_configs, load_meta_path_configs
+
+# Paths
+DATA_DIR = str(load_data_path_configs())
+
+# ------
+# INPUTS
+# ------
+# -- generating a wild card list (just the file base names)
+plate_name = hf.get_file_basenames(DATA_DIR, ext_target="sqlite")
+
+# -- getting rest input paths from helper funcitons
+PLATE_DATA = hf.get_plate_data()
+BARCODES = hf.get_barcodes()
+METADATA_DIR = hf.get_metadata_dir()
+
+# -------
+# OUTPUTS
+# -------
+# -- extended = list of the file names with given wildcard
+AGGREGATE_DATA = hf.aggregate_output()
+CELL_COUNTS = hf.cell_count_output()
+
+CELL_COUNTS_EXPANDED = expand(CELL_COUNTS, file_name=plate_name)
+AGGREGATE_DATA_EXPAND = expand(AGGREGATE_DATA, file_name=plate_name)
+
+ANNOTATED_DATA = hf.annotated_output()
+ANNOTATED_DATA_EXPAND = expand(ANNOTATED_DATA, file_name=plate_name)
+
+NORMALIZED_DATA = hf.normalized_output()
+NORMALIZED_DATA_EXPAND = expand(NORMALIZED_DATA, file_name=plate_name)
+
+SELECTED_FEATURE_DATA = hf.selected_features_output()
+SELECTED_FEATURE_DATA_EXPAND = expand(SELECTED_FEATURE_DATA, file_name=plate_name)
+
+CONSENSUS_DATA = hf.consensus_output()

--- a/workflows/rules/common.smk
+++ b/workflows/rules/common.smk
@@ -17,7 +17,7 @@ DATA_DIR = str(load_data_path_configs())
 # -- generating a wild card list (just the file base names)
 plate_name = hf.get_file_basenames(DATA_DIR, ext_target="sqlite")
 
-# -- getting rest input paths from helper funcitons
+# -- getting the rest of the input paths from helper functions
 PLATE_DATA = hf.get_plate_data()
 BARCODES = hf.get_barcodes()
 METADATA_DIR = hf.get_metadata_dir()

--- a/workflows/rules/feature_select.smk
+++ b/workflows/rules/feature_select.smk
@@ -3,12 +3,9 @@ configfile: "configs/configuration.yaml"
 
 rule feature_select:
     input:
-        expand("results/preprocessing/{plate_id}_normalized.csv.gz", plate_id=PLATE_IDS),
+        NORMALIZED_DATA_EXPAND,
     output:
-        expand(
-            "results/preprocessing/{plate_id}_feature_select.csv.gz",
-            plate_id=PLATE_IDS,
-        ),
+        SELECTED_FEATURE_DATA_EXPAND,
     params:
         feature_select_config=config["config_paths"]["feature_select"],
     log:
@@ -21,12 +18,9 @@ rule feature_select:
 
 rule create_consensus:
     input:
-        expand(
-            "results/preprocessing/{plate_id}_feature_select.csv.gz",
-            plate_id=PLATE_IDS,
-        ),
+        SELECTED_FEATURE_DATA_EXPAND,
     output:
-        "results/preprocessing/consensus.tsv.gz",
+        CONSENSUS_DATA,
     params:
         consensus_configs=config["config_paths"]["consensus_config"],
     log:

--- a/workflows/rules/preprocessing.smk
+++ b/workflows/rules/preprocessing.smk
@@ -30,49 +30,47 @@ configfile: "configs/configuration.yaml"
 
 rule aggregate:
     input:
-        sql_files="data/{plate_id}.sqlite",
-        barcodes="data/barcode_platemap.csv",
-        metadata="data/metadata",
+        sql_files=PLATE_DATA,
+        barcodes=BARCODES,
+        metadata=METADATA_DIR,
     output:
-        cell_counts="results/preprocessing/{plate_id}_cell_counts.tsv",
-        aggregate_profile="results/preprocessing/{plate_id}_aggregate.csv.gz",
+        aggregate_profile=AGGREGATE_OUTPUT,
+        cell_counts=CELL_COUNTS,
+    log:
+        "logs/aggregate_{file_name}.log",
     conda:
         "../envs/cytominer_env.yaml"
-    log:
-        "logs/aggregate_{plate_id}.log",
     params:
         aggregate_config=config["config_paths"]["single_cell"],
     script:
         "../scripts/aggregate_cells.py"
 
 
-rule annotate:
-    input:
-        barcodes="data/barcode_platemap.csv",
-        aggregate_profile="results/preprocessing/{plate_id}_aggregate.csv.gz",
-        metadata="data/metadata",
-    output:
-        "results/preprocessing/{plate_id}_augmented.csv.gz",
-    conda:
-        "../envs/cytominer_env.yaml"
-    log:
-        "logs/annotate_{plate_id}.log",
-    params:
-        annotate_config=config["config_paths"]["annotate"],
-    script:
-        "../scripts/annotate.py"
-
-
-rule normalize:
-    input:
-        "results/preprocessing/{plate_id}_augmented.csv.gz",
-    output:
-        "results/preprocessing/{plate_id}_normalized.csv.gz",
-    conda:
-        "../envs/cytominer_env.yaml"
-    log:
-        "logs/normalized_{plate_id}.log",
-    params:
-        normalize_config=config["config_paths"]["normalize"],
-    script:
-        "../scripts/normalize.py"
+# rule annotate:
+#     input:
+#         barcodes="data/barcode_platemap.csv",
+#         aggregate_profile="results/preprocessing/{plate_id}_aggregate.csv.gz",
+#         metadata="data/metadata",
+#     output:
+#         "results/preprocessing/{plate_id}_augmented.csv.gz",
+#     conda:
+#         "../envs/cytominer_env.yaml"
+#     log:
+#         "logs/annotate_{plate_id}.log",
+#     params:
+#         annotate_config=config["config_paths"]["annotate"],
+#     script:
+#         "../scripts/annotate.py"
+# rule normalize:
+#     input:
+#         "results/preprocessing/{plate_id}_augmented.csv.gz",
+#     output:
+#         "results/preprocessing/{plate_id}_normalized.csv.gz",
+#     conda:
+#         "../envs/cytominer_env.yaml"
+#     log:
+#         "logs/normalized_{plate_id}.log",
+#     params:
+#         normalize_config=config["config_paths"]["normalize"],
+#     script:
+#         "../scripts/normalize.py"

--- a/workflows/rules/preprocessing.smk
+++ b/workflows/rules/preprocessing.smk
@@ -34,7 +34,7 @@ rule aggregate:
         barcodes=BARCODES,
         metadata=METADATA_DIR,
     output:
-        aggregate_profile=AGGREGATE_OUTPUT,
+        aggregate_profile=AGGREGATE_DATA,
         cell_counts=CELL_COUNTS,
     log:
         "logs/aggregate_{file_name}.log",
@@ -46,31 +46,33 @@ rule aggregate:
         "../scripts/aggregate_cells.py"
 
 
-# rule annotate:
-#     input:
-#         barcodes="data/barcode_platemap.csv",
-#         aggregate_profile="results/preprocessing/{plate_id}_aggregate.csv.gz",
-#         metadata="data/metadata",
-#     output:
-#         "results/preprocessing/{plate_id}_augmented.csv.gz",
-#     conda:
-#         "../envs/cytominer_env.yaml"
-#     log:
-#         "logs/annotate_{plate_id}.log",
-#     params:
-#         annotate_config=config["config_paths"]["annotate"],
-#     script:
-#         "../scripts/annotate.py"
-# rule normalize:
-#     input:
-#         "results/preprocessing/{plate_id}_augmented.csv.gz",
-#     output:
-#         "results/preprocessing/{plate_id}_normalized.csv.gz",
-#     conda:
-#         "../envs/cytominer_env.yaml"
-#     log:
-#         "logs/normalized_{plate_id}.log",
-#     params:
-#         normalize_config=config["config_paths"]["normalize"],
-#     script:
-#         "../scripts/normalize.py"
+rule annotate:
+    input:
+        aggregate_profile=AGGREGATE_DATA,
+        barcodes=BARCODES,
+        metadata=METADATA_DIR,
+    output:
+        ANNOTATED_DATA,
+    conda:
+        "../envs/cytominer_env.yaml"
+    log:
+        "logs/annotate_{file_name}.log",
+    params:
+        annotate_config=config["config_paths"]["annotate"],
+    script:
+        "../scripts/annotate.py"
+
+
+rule normalize:
+    input:
+        ANNOTATED_DATA,
+    output:
+        NORMALIZED_DATA,
+    conda:
+        "../envs/cytominer_env.yaml"
+    log:
+        "logs/normalized_{file_name}.log",
+    params:
+        normalize_config=config["config_paths"]["normalize"],
+    script:
+        "../scripts/normalize.py"

--- a/workflows/scripts/aggregate_cells.py
+++ b/workflows/scripts/aggregate_cells.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 import pandas as pd
-import snakemake
+from snakemake.script import Snakemake
 import yaml
 from pycytominer.cyto_utils.cells import SingleCells
 

--- a/workflows/scripts/annotate.py
+++ b/workflows/scripts/annotate.py
@@ -3,7 +3,6 @@ import os
 from pathlib import Path
 
 import pandas as pd
-import snakemake
 import yaml
 from pycytominer.annotate import annotate
 

--- a/workflows/scripts/feature_select.py
+++ b/workflows/scripts/feature_select.py
@@ -1,7 +1,6 @@
 import logging
 from pathlib import Path
 
-import snakemake
 import yaml
 from pycytominer.feature_select import feature_select
 

--- a/workflows/scripts/normalize.py
+++ b/workflows/scripts/normalize.py
@@ -1,7 +1,6 @@
 import logging
 from pathlib import Path
 
-import snakemake
 import yaml
 from pycytominer.normalize import normalize
 

--- a/workflows/workflow/cp_process.smk
+++ b/workflows/workflow/cp_process.smk
@@ -12,8 +12,6 @@ include: "../rules/feature_select.smk"
 
 
 # appending logs
-# LOG_NAMES = glob_wildcards("logs/{log_name}.log").log_name
-# include: "rules/merge_logs.smk"
 rule all:
     input:
         AGGREGATE_DATA_EXPAND,
@@ -21,9 +19,3 @@ rule all:
         ANNOTATED_DATA_EXPAND,
         NORMALIZED_DATA_EXPAND,
         SELECTED_FEATURE_DATA_EXPAND,
-        # SELECTED_FEATURE_DATA_EXPAND,
-        # expand(
-        #     "results/preprocessing/{plate_id}_feature_select.csv.gz",
-        #     plate_id=PLATE_IDS,
-        # ),
-        # "results/preprocessing/consensus.tsv.gz",

--- a/workflows/workflow/cp_process.smk
+++ b/workflows/workflow/cp_process.smk
@@ -8,8 +8,7 @@ PLATE_IDS = glob_wildcards("data/{id}.sqlite").id
 # importing DAGs
 include: "../rules/common.smk"
 include: "../rules/preprocessing.smk"
-
-# include: ",,.rules/feature_select.smk"
+include: "../rules/feature_select.smk"
 
 
 # appending logs
@@ -17,11 +16,12 @@ include: "../rules/preprocessing.smk"
 # include: "rules/merge_logs.smk"
 rule all:
     input:
-        AGGREGATE_OUTPUT_EXPAND,
+        AGGREGATE_DATA_EXPAND,
         CELL_COUNTS_EXPANDED,
-        # expand("results/preprocessing/{plate_id}_cell_counts.tsv", plate_id=PLATE_IDS),
-        # expand("results/preprocessing/{plate_id}_augmented.csv.gz", plate_id=PLATE_IDS),
-        # expand("results/preprocessing/{plate_id}_normalized.csv.gz", plate_id=PLATE_IDS),
+        ANNOTATED_DATA_EXPAND,
+        NORMALIZED_DATA_EXPAND,
+        SELECTED_FEATURE_DATA_EXPAND,
+        # SELECTED_FEATURE_DATA_EXPAND,
         # expand(
         #     "results/preprocessing/{plate_id}_feature_select.csv.gz",
         #     plate_id=PLATE_IDS,

--- a/workflows/workflow/cp_process.smk
+++ b/workflows/workflow/cp_process.smk
@@ -1,13 +1,15 @@
 import glob
-
+from cytosnake.helpers import helper_funcs as hf
 
 # obtaining plate_ids
 PLATE_IDS = glob_wildcards("data/{id}.sqlite").id
 
 
 # importing DAGs
-include: "rules/preprocessing.smk"
-include: "rules/feature_select.smk"
+include: "../rules/common.smk"
+include: "../rules/preprocessing.smk"
+
+# include: ",,.rules/feature_select.smk"
 
 
 # appending logs
@@ -15,12 +17,13 @@ include: "rules/feature_select.smk"
 # include: "rules/merge_logs.smk"
 rule all:
     input:
-        expand("results/preprocessing/{plate_id}_aggregate.csv.gz", plate_id=PLATE_IDS),  # expected outputs from the first DAG "Preprocessing"
-        expand("results/preprocessing/{plate_id}_cell_counts.tsv", plate_id=PLATE_IDS),
-        expand("results/preprocessing/{plate_id}_augmented.csv.gz", plate_id=PLATE_IDS),
-        expand("results/preprocessing/{plate_id}_normalized.csv.gz", plate_id=PLATE_IDS),
-        expand(
-            "results/preprocessing/{plate_id}_feature_select.csv.gz",
-            plate_id=PLATE_IDS,
-        ),
-        "results/preprocessing/consensus.tsv.gz",
+        AGGREGATE_OUTPUT_EXPAND,
+        CELL_COUNTS_EXPANDED,
+        # expand("results/preprocessing/{plate_id}_cell_counts.tsv", plate_id=PLATE_IDS),
+        # expand("results/preprocessing/{plate_id}_augmented.csv.gz", plate_id=PLATE_IDS),
+        # expand("results/preprocessing/{plate_id}_normalized.csv.gz", plate_id=PLATE_IDS),
+        # expand(
+        #     "results/preprocessing/{plate_id}_feature_select.csv.gz",
+        #     plate_id=PLATE_IDS,
+        # ),
+        # "results/preprocessing/consensus.tsv.gz",

--- a/workflows/workflow/cp_process.smk
+++ b/workflows/workflow/cp_process.smk
@@ -1,17 +1,14 @@
 import glob
 from cytosnake.helpers import helper_funcs as hf
 
-# obtaining plate_ids
-PLATE_IDS = glob_wildcards("data/{id}.sqlite").id
 
-
-# importing DAGs
+# importing Modules
 include: "../rules/common.smk"
 include: "../rules/preprocessing.smk"
 include: "../rules/feature_select.smk"
 
 
-# appending logs
+# expected outputs from workflow
 rule all:
     input:
         AGGREGATE_DATA_EXPAND,


### PR DESCRIPTION
## About this PR

This PR introduces the first implementations of helper functions that standardizes all inputs and output paths before executing a workflow. 

## What is new?

A new module has been added known as `helper_funcs` that attempts to solve the issues with `snakemake` strict naming rules. 

- Contains functions that predefines file paths

A new rule module known as `common.smk:`

- Mains goal is to standardize input and output paths before sending it into the workflow
    - helper functions are imported and executed in within this rule module

## Motivation and implementation

![helper_funcs](https://user-images.githubusercontent.com/31600622/223276689-cee231c7-31ec-48f6-a2bb-7c379853ed54.png)

> Simple schematic on how the `helper_funcs` module is involved in generating paths. It loads in the configurations found in `cytosnake`, and uses those configurations to generate the input and output paths.
> 

One of the issues that @jenna-tomkinson  found is that `Snakemake` expects an exact file names in order for a workflow to successfully work. This means that any files names that do not have the expected files names will cause the workflow to not execute. Fortunately, there is a common work around this issue and it is using python functions as inputs for a `Snakemake` workflow [[source](https://snakemake.readthedocs.io/en/stable/tutorial/advanced.html#step-3-input-functions)] . Due to this feature that `Snakemake` has, this drove the development of the `helper_funcs` module, pre-define the file paths before declaring it the `Snakemake` based workflows.