### PR TITLE
Update `get_input()` function to `get_data_path()` and implement it within modules

### DIFF
--- a/configs/configuration.yaml
+++ b/configs/configuration.yaml
@@ -1,6 +1,6 @@
 config_name: cytosnake_configs
 
-env_manager: conda
+env_manager: mamba
 
 # computation configs
 analysis_configs:

--- a/cytosnake/helpers/datapaths.py
+++ b/cytosnake/helpers/datapaths.py
@@ -71,10 +71,10 @@ def get_metadata_dir() -> str:
 # --------------------------
 # Main path builder function
 # --------------------------
-def build_path(data_type: str, use_converted: Optional[bool] = False) -> str:
+def build_path(input_type: str, use_converted: Optional[bool] = False) -> str:
     """Builds an output string path pointing to a specific dataset
 
-    data_type : str
+    input_type : str
         type of dataset string path to be build.
 
     use_converted : Optional[bool]
@@ -97,11 +97,11 @@ def build_path(data_type: str, use_converted: Optional[bool] = False) -> str:
     data_configs = GENERAL_CONFIGS["data_configs"]
 
     # loading in the config
-    if data_type not in data_configs["data_types"].keys():
-        raise ValueError(f"`{data_type}` is not a supported dataset")
+    if input_type not in data_configs["data_types"].keys():
+        raise ValueError(f"`{input_type}` is not a supported dataset")
 
     # loading in data_type specific configs
-    selected_datatype = data_configs["data_types"][data_type]
+    selected_datatype = data_configs["data_types"][input_type]
 
     # loading default path components into variables
     header = cyto_paths.get_results_dir_path()
@@ -115,7 +115,7 @@ def build_path(data_type: str, use_converted: Optional[bool] = False) -> str:
 
     # plate_data requires some of the defaults to be change since it is in a different
     # folder
-    if data_type == "plate_data":
+    if input_type == "plate_data":
         header = cyto_paths.get_project_root() / "data"
         suffix = ""
 

--- a/workflows/rules/aggregate.smk
+++ b/workflows/rules/aggregate.smk
@@ -33,7 +33,7 @@ Returns
 rule aggregate:
     input:
         sql_files=get_input(
-            data_type=config["aggregate_configs"]["params"]["input_data"],
+            input_type=config["aggregate_configs"]["params"]["input_data"],
             use_converted=DATA_CONFIGS["use_converted_plate_data"],
         ),
         barcodes=BARCODES,

--- a/workflows/rules/aggregate.smk
+++ b/workflows/rules/aggregate.smk
@@ -32,7 +32,7 @@ Returns
 
 rule aggregate:
     input:
-        sql_files=get_input(
+        sql_files=get_data_path(
             input_type=config["aggregate_configs"]["params"]["input_data"],
             use_converted=DATA_CONFIGS["use_converted_plate_data"],
         ),

--- a/workflows/rules/aggregate.smk
+++ b/workflows/rules/aggregate.smk
@@ -39,7 +39,7 @@ rule aggregate:
         barcodes=BARCODES,
         metadata=METADATA_DIR,
     output:
-        aggregate_profile=AGGREGATE_DATA,
+        aggregate_profile=get_data_path(input_type="aggregated", tolist=True),
         cell_counts=CELL_COUNTS,
     log:
         "logs/aggregate_{file_name}.log",

--- a/workflows/rules/annotate.smk
+++ b/workflows/rules/annotate.smk
@@ -29,7 +29,7 @@ Returns:
 
 rule annotate:
     input:
-        profile=get_input(
+        profile=get_data_path(
             input_type=config["annotate_configs"]["params"]["input_data"],
             use_converted=DATA_CONFIGS["use_converted_plate_data"],
         ),

--- a/workflows/rules/annotate.smk
+++ b/workflows/rules/annotate.smk
@@ -36,7 +36,7 @@ rule annotate:
         barcodes=BARCODES,
         metadata=METADATA_DIR,
     output:
-        ANNOTATED_DATA,
+        get_data_path(input_type="annotated"),
     conda:
         "../envs/cytominer_env.yaml"
     log:

--- a/workflows/rules/annotate.smk
+++ b/workflows/rules/annotate.smk
@@ -30,7 +30,7 @@ Returns:
 rule annotate:
     input:
         profile=get_input(
-            data_type=config["annotate_configs"]["params"]["input_data"],
+            input_type=config["annotate_configs"]["params"]["input_data"],
             use_converted=DATA_CONFIGS["use_converted_plate_data"],
         ),
         barcodes=BARCODES,

--- a/workflows/rules/common.smk
+++ b/workflows/rules/common.smk
@@ -78,17 +78,40 @@ CELL_COUNTS = datapaths.build_path(input_type="consensus")
 CELL_COUNTS_EXPANDED = expand(CELL_COUNTS, basename=plate_name)
 
 
-def get_input(
+def get_data_path(
     input_type: str,
     use_converted: Optional[bool] = False,
     tolist: Optional[bool] = False,
 ) -> str:
-    """Returns absolute path of an input
+    """Returns absolute path of an input.
+
+    The supported input types are:
+
+    plate_data (level 2):
+        Single cell morphology dataset
+    annotated (level 2.5):
+        Dataset that has been agumented with metdata. This provides additional
+        information to the profiles like pertubations types, cell types,
+        well locations etc.
+    aggregated (level 3):
+        Aggregated single-cell morphology dataset.
+    normalized (level 4a):
+        Normalized profiles.
+    feature_select (level 4b):
+        selected features from given profile
+    consensus (level 5)
+        profile containing unique signatures pertaining to a specific pertubations
+        and/or external factors.
+
+    Other input types:
+
+    cell_counts:
+        refers to the number of cells within a well
 
     Parameters
     ----------
     input_type: str
-        data
+        type of inp
 
     use_conveted: Optional[bool]
         flag to return path conveted single-cell data
@@ -102,34 +125,41 @@ def get_input(
         returns path of select data type input path`
     """
 
-    # checking
+    # checking if provided `input_type` is valid
     if input_type not in DATA_CONFIGS["input_types"].keys():
         raise ValueError(f"`{input_type}` is not a supported datatype.")
 
-    match input_type:
-        case "cell_counts":
-            return
-        case "plate_data":
-            if use_converted:
-                return CYTOTABLE_CONVERTED_PLATE_DATA
-            return PLATE_DATA
-        case "aggregated":
-            if tolist:
-                return AGGREGATE_DATA_EXPAND
-            return AGGREGATE_DATA
-        case "annotated":
-            if tolist:
-                return ANNOTATED_DATA_EXPAND
-            return ANNOTATED_DATA
-        case "normalized":
-            if tolist:
-                return NORMALIZED_DATA_EXPAND
-            return NORMALIZED_DATA
-        case "feature_select":
-            if tolist:
-                return SELECTED_FEATURE_DATA_EXPAND
-            return SELECTED_FEATURE_DATA
-        case "consensus":
-            if tolist:
-                return CONSENSUS_DATA_EXPAND
-            return CONSENSUS_DATA
+    # returning constructed path based on in `input_type`
+    return (
+        expand(datapaths.build_path(input_type=input_type), basename=plate_name)
+        if tolist
+        else datapaths.build_path(input_type=input_type)
+    )
+
+    # match input_type:
+    #     case "cell_counts":
+    #         return
+    #     case "plate_data":
+    #         if use_converted:
+    #             return CYTOTABLE_CONVERTED_PLATE_DATA
+    #         return PLATE_DATA
+    #     case "aggregated":
+    #         if tolist:
+    #             return AGGREGATE_DATA_EXPAND
+    #         return AGGREGATE_DATA
+    #     case "annotated":
+    #         if tolist:
+    #             return ANNOTATED_DATA_EXPAND
+    #         return ANNOTATED_DATA
+    #     case "normalized":
+    #         if tolist:
+    #             return NORMALIZED_DATA_EXPAND
+    #         return NORMALIZED_DATA
+    #     case "feature_select":
+    #         if tolist:
+    #             return SELECTED_FEATURE_DATA_EXPAND
+    #         return SELECTED_FEATURE_DATA
+    #     case "consensus":
+    #         if tolist:
+    #             return CONSENSUS_DATA_EXPAND
+    #         return CONSENSUS_DATA

--- a/workflows/rules/common.smk
+++ b/workflows/rules/common.smk
@@ -18,7 +18,7 @@ DATA_CONFIGS = CYTOSNAKE_CONFIGS["data_configs"]
 # INPUTS
 # ------
 # generating a wild card list (just the file base names)
-plate_name = datapaths.get_all_basenames(DATA_DIR, ext_target="sqlite")
+FILE_BASE_NAMES = datapaths.get_all_basenames(DATA_DIR, ext_target="sqlite")
 
 # getting the rest of the input paths from helper functions
 
@@ -42,40 +42,40 @@ METADATA_DIR = datapaths.get_metadata_dir()
 # To understand the level of data, please refere to PyCytominer documentation
 # https://github.com/cytomining/pycytominer
 
-# Level 2 data: converted into parquet format
-CYTOTABLE_CONVERTED_PLATE_DATA = datapaths.build_path(
-    input_type="plate_data", use_converted=True
-)
-CYTOTABLE_CONVERTED_PLATE_DATA_EXTENDED = expand(
-    CYTOTABLE_CONVERTED_PLATE_DATA, basename=plate_name
-)
+# # Level 2 data: converted into parquet format
+# CYTOTABLE_CONVERTED_PLATE_DATA = datapaths.build_path(
+#     input_type="plate_data", use_converted=True
+# )
+# CYTOTABLE_CONVERTED_PLATE_DATA_EXTENDED = expand(
+#     CYTOTABLE_CONVERTED_PLATE_DATA, basename=FILE_BASE_NAMES
+# )
 
-# level 2.5 data: annotated level 2 data based on given metadata (e.g treatments)
-ANNOTATED_DATA = datapaths.build_path(input_type="annotated")
-ANNOTATED_DATA_EXPAND = expand(ANNOTATED_DATA, basename=plate_name)
+# # level 2.5 data: annotated level 2 data based on given metadata (e.g treatments)
+# ANNOTATED_DATA = datapaths.build_path(input_type="annotated")
+# ANNOTATED_DATA_EXPAND = expand(ANNOTATED_DATA, basename=FILE_BASE_NAMES)
 
-# level 3 data: aggregated profile based on given aggregation level
-# (e.g aggregating single-cell data to the well level)
-AGGREGATE_DATA = datapaths.build_path(input_type="aggregated")
-AGGREGATE_DATA_EXPAND = expand(AGGREGATE_DATA, basename=plate_name)
+# # level 3 data: aggregated profile based on given aggregation level
+# # (e.g aggregating single-cell data to the well level)
+# AGGREGATE_DATA = datapaths.build_path(input_type="aggregated")
+# AGGREGATE_DATA_EXPAND = expand(AGGREGATE_DATA, basename=FILE_BASE_NAMES)
 
-# level 4a data: noramlzied profile
-NORMALIZED_DATA = datapaths.build_path(input_type="normalized")
-NORMALIZED_DATA_EXPAND = expand(NORMALIZED_DATA, basename=plate_name)
+# # level 4a data: noramlzied profile
+# NORMALIZED_DATA = datapaths.build_path(input_type="normalized")
+# NORMALIZED_DATA_EXPAND = expand(NORMALIZED_DATA, basename=FILE_BASE_NAMES)
 
-# level 4b: selected features profile
-SELECTED_FEATURE_DATA = datapaths.build_path(input_type="feature_select")
-SELECTED_FEATURE_DATA_EXPAND = expand(SELECTED_FEATURE_DATA, basename=plate_name)
+# # level 4b: selected features profile
+# SELECTED_FEATURE_DATA = datapaths.build_path(input_type="feature_select")
+# SELECTED_FEATURE_DATA_EXPAND = expand(SELECTED_FEATURE_DATA, basename=FILE_BASE_NAMES)
 
-# level 5: Consensus profile captures unique signatures that resulted from
-# any external factor (e.g pertubations)
-CONSENSUS_DATA = datapaths.build_path(input_type="consensus")
-CONSENSUS_DATA_EXPAND = expand(CONSENSUS_DATA, basename=plate_name)
+# # level 5: Consensus profile captures unique signatures that resulted from
+# # any external factor (e.g pertubations)
+# CONSENSUS_DATA = datapaths.build_path(input_type="consensus")
+# CONSENSUS_DATA_EXPAND = expand(CONSENSUS_DATA, basename=FILE_BASE_NAMES)
 
-# other outputsa
-# Cell counts: cell counts per well in level 2 data
-CELL_COUNTS = datapaths.build_path(input_type="consensus")
-CELL_COUNTS_EXPANDED = expand(CELL_COUNTS, basename=plate_name)
+# # other outputsa
+# # Cell counts: cell counts per well in level 2 data
+# CELL_COUNTS = datapaths.build_path(input_type="consensus")
+# CELL_COUNTS_EXPANDED = expand(CELL_COUNTS, basename=FILE_BASE_NAMES)
 
 
 def get_data_path(
@@ -126,12 +126,19 @@ def get_data_path(
     """
 
     # checking if provided `input_type` is valid
-    if input_type not in DATA_CONFIGS["input_types"].keys():
+    if input_type not in DATA_CONFIGS["data_types"].keys():
         raise ValueError(f"`{input_type}` is not a supported datatype.")
+
+    # checking if the user wants to use converted dataset
+    if input_type == "plate_data" and use_converted is True:
+        if tolist:
+            return expand(datapaths.build_path(input_type="plate_data", use_converted=True), basename=FILE_BASE_NAMES)
+        return datapaths.build_path(input_type="plate_data", use_converted=True)
+
 
     # returning constructed path based on in `input_type`
     return (
-        expand(datapaths.build_path(input_type=input_type), basename=plate_name)
+        expand(datapaths.build_path(input_type=input_type), basename=FILE_BASE_NAMES)
         if tolist
         else datapaths.build_path(input_type=input_type)
     )

--- a/workflows/rules/common.smk
+++ b/workflows/rules/common.smk
@@ -27,7 +27,7 @@ plate_name = datapaths.get_all_basenames(DATA_DIR, ext_target="sqlite")
 #
 # METADATA_DIR: contains information of what has been added to the cells
 # BARCODES: Unique id that points to a specific level 2 dataset (plate data)
-PLATE_DATA = datapaths.build_path(data_type="plate_data")
+PLATE_DATA = datapaths.build_path(input_type="plate_data")
 BARCODES = datapaths.get_barcodes()
 METADATA_DIR = datapaths.get_metadata_dir()
 
@@ -44,42 +44,42 @@ METADATA_DIR = datapaths.get_metadata_dir()
 
 # Level 2 data: converted into parquet format
 CYTOTABLE_CONVERTED_PLATE_DATA = datapaths.build_path(
-    data_type="plate_data", use_converted=True
+    input_type="plate_data", use_converted=True
 )
 CYTOTABLE_CONVERTED_PLATE_DATA_EXTENDED = expand(
     CYTOTABLE_CONVERTED_PLATE_DATA, basename=plate_name
 )
 
 # level 2.5 data: annotated level 2 data based on given metadata (e.g treatments)
-ANNOTATED_DATA = datapaths.build_path(data_type="annotated")
+ANNOTATED_DATA = datapaths.build_path(input_type="annotated")
 ANNOTATED_DATA_EXPAND = expand(ANNOTATED_DATA, basename=plate_name)
 
 # level 3 data: aggregated profile based on given aggregation level
 # (e.g aggregating single-cell data to the well level)
-AGGREGATE_DATA = datapaths.build_path(data_type="aggregated")
+AGGREGATE_DATA = datapaths.build_path(input_type="aggregated")
 AGGREGATE_DATA_EXPAND = expand(AGGREGATE_DATA, basename=plate_name)
 
 # level 4a data: noramlzied profile
-NORMALIZED_DATA = datapaths.build_path(data_type="normalized")
+NORMALIZED_DATA = datapaths.build_path(input_type="normalized")
 NORMALIZED_DATA_EXPAND = expand(NORMALIZED_DATA, basename=plate_name)
 
 # level 4b: selected features profile
-SELECTED_FEATURE_DATA = datapaths.build_path(data_type="feature_select")
+SELECTED_FEATURE_DATA = datapaths.build_path(input_type="feature_select")
 SELECTED_FEATURE_DATA_EXPAND = expand(SELECTED_FEATURE_DATA, basename=plate_name)
 
 # level 5: Consensus profile captures unique signatures that resulted from
 # any external factor (e.g pertubations)
-CONSENSUS_DATA = datapaths.build_path(data_type="consensus")
+CONSENSUS_DATA = datapaths.build_path(input_type="consensus")
 CONSENSUS_DATA_EXPAND = expand(CONSENSUS_DATA, basename=plate_name)
 
 # other outputsa
 # Cell counts: cell counts per well in level 2 data
-CELL_COUNTS = datapaths.build_path(data_type="consensus")
+CELL_COUNTS = datapaths.build_path(input_type="consensus")
 CELL_COUNTS_EXPANDED = expand(CELL_COUNTS, basename=plate_name)
 
 
 def get_input(
-    data_type: str,
+    input_type: str,
     use_converted: Optional[bool] = False,
     tolist: Optional[bool] = False,
 ) -> str:
@@ -87,7 +87,7 @@ def get_input(
 
     Parameters
     ----------
-    data_type: str
+    input_type: str
         data
 
     use_conveted: Optional[bool]
@@ -103,10 +103,10 @@ def get_input(
     """
 
     # checking
-    if data_type not in DATA_CONFIGS["data_types"].keys():
-        raise ValueError(f"`{data_type}` is not a supported datatype.")
+    if input_type not in DATA_CONFIGS["input_types"].keys():
+        raise ValueError(f"`{input_type}` is not a supported datatype.")
 
-    match data_type:
+    match input_type:
         case "cell_counts":
             return
         case "plate_data":

--- a/workflows/rules/cytotable_convert.smk
+++ b/workflows/rules/cytotable_convert.smk
@@ -19,7 +19,7 @@ rule convert:
     input:
         get_data_path(input_type=config["cytotable_convert"]["params"]["input_data"]),
     output:
-        CYTOTABLE_CONVERTED_PLATE_DATA,
+        get_data_path(input_type="plate_data", use_converted=config["data_configs"]["use_converted_plate_data"]),
     conda:
         "../envs/cytotable.yaml"
     params:

--- a/workflows/rules/cytotable_convert.smk
+++ b/workflows/rules/cytotable_convert.smk
@@ -17,7 +17,7 @@ Returns:
 
 rule convert:
     input:
-        get_input(input_type=config["cytotable_convert"]["params"]["input_data"]),
+        get_data_path(input_type=config["cytotable_convert"]["params"]["input_data"]),
     output:
         CYTOTABLE_CONVERTED_PLATE_DATA,
     conda:

--- a/workflows/rules/cytotable_convert.smk
+++ b/workflows/rules/cytotable_convert.smk
@@ -17,7 +17,7 @@ Returns:
 
 rule convert:
     input:
-        get_input(data_type=config["cytotable_convert"]["params"]["input_data"]),
+        get_input(input_type=config["cytotable_convert"]["params"]["input_data"]),
     output:
         CYTOTABLE_CONVERTED_PLATE_DATA,
     conda:

--- a/workflows/rules/feature_select.smk
+++ b/workflows/rules/feature_select.smk
@@ -24,7 +24,7 @@ Returns
 rule feature_select:
     input:
         get_input(
-            data_type=config["feature_select_configs"]["params"]["input_data"],
+            input_type=config["feature_select_configs"]["params"]["input_data"],
             tolist=True,
         ),
     output:

--- a/workflows/rules/feature_select.smk
+++ b/workflows/rules/feature_select.smk
@@ -23,7 +23,7 @@ Returns
 
 rule feature_select:
     input:
-        get_input(
+        get_data_path(
             input_type=config["feature_select_configs"]["params"]["input_data"],
             tolist=True,
         ),

--- a/workflows/rules/feature_select.smk
+++ b/workflows/rules/feature_select.smk
@@ -28,7 +28,7 @@ rule feature_select:
             tolist=True,
         ),
     output:
-        SELECTED_FEATURE_DATA_EXPAND,
+        get_data_path(input_type="feature_select", tolist=True),
     params:
         feature_select_config=config["feature_select_configs"],
     log:

--- a/workflows/rules/generate_consensus.smk
+++ b/workflows/rules/generate_consensus.smk
@@ -24,7 +24,7 @@ rule create_consensus:
     input:
         get_data_path(input_type=config["consensus_configs"]["params"]["input_data"]),
     output:
-        CONSENSUS_DATA,
+        get_data_path(input_type="consensus"),
     params:
         consensus_configs=config["config_paths"]["consensus_config"],
     log:

--- a/workflows/rules/generate_consensus.smk
+++ b/workflows/rules/generate_consensus.smk
@@ -22,7 +22,7 @@ Return:
 
 rule create_consensus:
     input:
-        get_input(data_type=config["consensus_configs"]["params"]["input_data"]),
+        get_input(input_type=config["consensus_configs"]["params"]["input_data"]),
     output:
         CONSENSUS_DATA,
     params:

--- a/workflows/rules/generate_consensus.smk
+++ b/workflows/rules/generate_consensus.smk
@@ -22,7 +22,7 @@ Return:
 
 rule create_consensus:
     input:
-        get_input(input_type=config["consensus_configs"]["params"]["input_data"]),
+        get_data_path(input_type=config["consensus_configs"]["params"]["input_data"]),
     output:
         CONSENSUS_DATA,
     params:

--- a/workflows/rules/normalize.smk
+++ b/workflows/rules/normalize.smk
@@ -24,7 +24,7 @@ Output
 
 rule normalize:
     input:
-        get_input(
+        get_data_path(
             input_type=config["normalize_configs"]["params"]["input_data"],
             use_converted=DATA_CONFIGS["use_converted_plate_data"],
         ),

--- a/workflows/rules/normalize.smk
+++ b/workflows/rules/normalize.smk
@@ -25,7 +25,7 @@ Output
 rule normalize:
     input:
         get_input(
-            data_type=config["normalize_configs"]["params"]["input_data"],
+            input_type=config["normalize_configs"]["params"]["input_data"],
             use_converted=DATA_CONFIGS["use_converted_plate_data"],
         ),
     output:

--- a/workflows/rules/normalize.smk
+++ b/workflows/rules/normalize.smk
@@ -29,7 +29,7 @@ rule normalize:
             use_converted=DATA_CONFIGS["use_converted_plate_data"],
         ),
     output:
-        NORMALIZED_DATA,
+        get_data_path(input_type="normalized"),
     conda:
         "../envs/cytominer_env.yaml"
     log:

--- a/workflows/scripts/annotate.py
+++ b/workflows/scripts/annotate.py
@@ -29,6 +29,13 @@ def annotate_cells(
     configs:
         path to configuration file
     """
+    # raise error if input profile ends with `.sqlite`
+    if isinstance(profile, str) and pathlib.Path(profile).suffix == ".sqlite":
+        raise ValueError(
+            "Cannot use sqlite files for annotation,"
+            "please convert to parquet or csv files formats "
+            )
+
     # initiating Logger
     log_path = pathlib.Path(log_file).absolute()
     logging.basicConfig(

--- a/workflows/workflow/cp_process_singlecells.smk
+++ b/workflows/workflow/cp_process_singlecells.smk
@@ -43,7 +43,7 @@ include: "../rules/feature_select.smk"
 # define expected outputs
 rule all:
     input:
-        CYTOTABLE_CONVERTED_PLATE_DATA_EXTENDED,
-        ANNOTATED_DATA_EXPAND,
-        NORMALIZED_DATA_EXPAND,
-        SELECTED_FEATURE_DATA_EXPAND,
+        get_data_path(input_type="plate_data", tolist=True, use_converted=config["data_configs"]["use_converted_plate_data"]),
+        get_data_path(input_type="annotated", tolist=True),
+        get_data_path(input_type="normalized", tolist=True),
+        get_data_path(input_type="feature_select", tolist=True),


### PR DESCRIPTION
## About 

This PR introduces an update to the previously developed helper function `get_inputs()` #60 . 

There are the changes:
 - renamed `get_input` to `get_data_path()` 
 - changed `data_type` parameter to `input_type` 
 - replaced `inputs` and `ouputs` parameter 
 - removed output constants in `common.smk` module
 - workflow `rule all` constants are now replaced with `get_data_path()` function calls